### PR TITLE
Simplified crypto.subtle access for wider support

### DIFF
--- a/lib/totp.js
+++ b/lib/totp.js
@@ -35,35 +35,23 @@ TOTP.prototype = {
         // compute time shift to byte array
         const _time       = Math.floor((Date.now() / 1000 - bias) / timeStep);
         const _timeFactor = this._int32ToByteArray(_time);
+        
+        // Check webcrypto API
+        if (typeof crypto.subtle !== 'undefined'){
 
-        // compute HMACSHA1(key, shift)
-        if ( typeof window !== 'undefined' ) {
-            
-            // browser. use crypto.subtle
-            const key = await window.crypto.subtle.importKey(
-                "raw",       // key format 
-                _keybytes, { // algorithm details
-                    name: "HMAC",
-                    hash: {
-                        name: "SHA-1"
-                    }
-                },
+            // compute HMACSHA1(key, shift)
+            const key = await crypto.subtle.importKey("raw", _keybytes,
+                {name: "HMAC", hash: { name: "SHA-1" }},
                 false,   // no export 
                 ["sign"] // what this key can do
             );
-            
-            const signature = await window.crypto.subtle.sign(
-                "HMAC",
-                key,
-                _timeFactor
-            );
-            
+            const signature = await crypto.subtle.sign( "HMAC", key, _timeFactor );
             return this._truncate( new Uint8Array( signature ) );
         } else {
 
-            // node.js. use crypto module
+            // old nodejs. use crypto module
             const signature = 
-                require('crypto')
+                require('node:crypto')
                     .createHmac('sha1', _keybytes)
                     .update( new Uint8Array( _timeFactor ) )
                     .digest();


### PR DESCRIPTION
Tested on Node (14, 16, 18, 20 and 22), Chrome 129 and CF workers.

Accessing crypto.subtle through window.crypto.subtle isn't necessary for browsers, just a bit more explicit.

I tested it on all LTS versions of Node (on replit). 14 and 16 default to old method with the check `typeof crypto.subtle !== 'undefined'`, 18+ returns true.

Unrelated note but `await` keyword doesn't work as-is in Node v14 REPL (works fine inside functions defined as async). Needed to use `--experimental-repl-await` REPL option.